### PR TITLE
Update bind.pm for Bind with threads disabled

### DIFF
--- a/lib/bind.pm
+++ b/lib/bind.pm
@@ -372,7 +372,11 @@ sub bind_update {
 		$rrdata .= ":" . $value->{summary}->{Lost};
 		$rrdata .= ":0:0:0";
 		$value = $data->{bind}->{statistics}->{taskmgr};
-		$rrdata .= ":" . $value->{'thread-model'}->{'worker-threads'};
+		if ($value->{'thread-model'}->{'worker-threads'}) {
+			$rrdata .= ":" . $value->{'thread-model'}->{'worker-threads'};
+		} else {
+			$rrdata .= ":" . "1";
+		}
 		$rrdata .= ":" . $value->{'thread-model'}->{'default-quantum'};
 		$rrdata .= ":" . $value->{'thread-model'}->{'tasks-running'};
 		$rrdata .= ":0:0:0";


### PR DESCRIPTION
On ArchLinux, the default bind package has threads disabled. And then statistics xml doesn't contain $value->{'thread-model'}->{'worker-threads'}.

I am not a Perl guru so I am not sure if I fixed it correctly but the fix works fine for me.
