### PR TITLE
new optional https_url config value

### DIFF
--- a/monitorix.cgi
+++ b/monitorix.cgi
@@ -215,7 +215,7 @@ my $conf = new Config::General(
 );
 %config = $conf->getall;
 
-$config{url} = $ENV{HTTPS} ? "https://" . $ENV{HTTP_HOST} : "http://" . $ENV{HTTP_HOST};
+$config{url} = ($ENV{HTTPS} || $config{https_url} eq "y") ? "https://" . $ENV{HTTP_HOST} : "http://" . $ENV{HTTP_HOST};
 $config{hostname} = $config{hostname} || $ENV{SERVER_NAME};
 if(!($config{hostname})) {	# called from the command line
 	$config{hostname} = "127.0.0.1";


### PR DESCRIPTION
Hey,
I am suggesting a simple config addition.

When I started using https on my nginx, I decided to let Monitorix bind on 127.0.0.1 and use nginx as reverse-proxy. That worked fine, but Monitorix cgi kept using http:// scheme for its urls ($config{url} variable all over the Monitorix) which makes sense as it don't know I am proxying http requests which are https when looking at it from the outside world.

To illustrate - here is my setup:
BROWSER <-https-> NGINX (0.0.0.0) <-http-> MONITORIX (127.0.0.1)

This way I can protect monitorix and other similar locally-listening servers via nginx auth and https transfer.

The proposed change adds a new optional variable https_url which can be added to Monitorix confix file. When it's https_url = y, Monitorix will use https:// scheme for all links even when the internal monitorix server is listening for HTTP requests. All existing functionality for HTTPS CGI detection etc remains. I have tested all three cases (https_url se to y, to n and not set). Worked fine.

Alternatively it could be solved by using relative URLs everywhere (respecting base_url and url from config)....

Cheers,
Mario
