### PR TITLE
first draft at a proper Makefile

### DIFF
--- a/monitorix.in
+++ b/monitorix.in
@@ -46,8 +46,8 @@ $SIG{'TERM'} = 'INT_handler';
 $SIG{'CHLD'} = 'CHLD_handler';
 $SIG{'HUP' } = 'HUP_handler';
 
-use constant VERSION	=> "3.5.1";
-use constant RELDATE	=> "06-May-2014";
+use constant VERSION	=> "@VERSION@";
+use constant RELDATE	=> "@RELEASEDATE@";
 
 my @suppsys = ("Linux", "FreeBSD", "OpenBSD", "NetBSD");
 our %config;


### PR DESCRIPTION
I still need to add two sections, 
1) The redhat init script (but redhat now uses systemd).
2) For the debian init script

It also needs to have the uninstall section completely re-rewritten for monitorix.  You see I just copied over my Makefile from profile-sync-daemon.

For me, this test works for Arch Linux:

```
make DESTDIR=test BASEDIR=/srv/http/monitorix install-systemd-all
```
