### PR TITLE
Add custom url config option for top logo link

### DIFF
--- a/monitorix
+++ b/monitorix
@@ -196,7 +196,7 @@ EOF
   <table>
     <tr>
       <td>
-        <a href="http://www.monitorix.org/"><img src="$base_url$config{logo_top}" border="0"></a>
+        <a href="$config{logo_top_url}"><img src="$base_url$config{logo_top}" border="0"></a>
       </td>
     </tr>
     <tr>

--- a/monitorix.conf
+++ b/monitorix.conf
@@ -667,6 +667,7 @@ usage_dir = usage/
 report_dir = reports/
 favicon = monitorixico.png
 logo_top = logo_top.png
+logo_top_url = http://www.monitorix.org/
 logo_bottom = logo_bot.png
 
 <theme>


### PR DESCRIPTION
Might be useful to have a different link if you can change the logo. Maybe there could be a "powered by monitorix" at the bottom even if you change the logo at the top?