### PR TITLE
If SMART ID 194 is empty, try ID 190.

### DIFF
--- a/lib/disk.pm
+++ b/lib/disk.pm
@@ -220,6 +220,11 @@ sub disk_update {
 						$temp = $tmp[9];
 						chomp($temp);
 					}
+          if(/^190/ && /Airflow_Temperature_Cel/) {
+            my @tmp = split(' ', $_);
+            $temp = $tmp[9] unless $temp;
+            chomp($temp);
+          }
 					if(/^197/ && /Current_Pending_Sector/) {
 						my @tmp = split(' ', $_);
 						$smart2 = $tmp[9];


### PR DESCRIPTION
Suggested improvement to address https://github.com/mikaku/Monitorix/issues/121