### PR TITLE
added name substring match

### DIFF
--- a/lib/process.pm
+++ b/lib/process.pm
@@ -181,6 +181,11 @@ sub process_update {
 							$pro++;
 							next;
 						}
+						if(index($3, $p) != -1) {
+							push(@pid, $1);
+							$pro++;
+							next;
+						}
 					}
 					if(substr($p, 0, 15) eq substr($_, 6, 15)) {
 						push(@pid, $1);


### PR DESCRIPTION
The substring match is useful for things like java applications, that all use the same core process, but the command line is what differentiates them. i.e., ActiveMQ, which I match on the JAR file is:

16532 java /usr/bin/java -Xms1G -Xmx1G -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=/opt/activemq/conf/login.config -Dcom.sun.management.jmxremote -Djava.awt.headless=true -Djava.io.tmpdir=/opt/activemq/tmp -Dactivemq.classpath=/opt/activemq/conf; -Dactivemq.home=/opt/activemq -Dactivemq.base=/opt/activemq -Dactivemq.conf=/opt/activemq/conf -Dactivemq.data=/opt/activemq/data -jar /opt/activemq/bin/activemq.jar start