### PR TITLE
Fix a legend diaplay bug in nvidia.pm

### DIFF
--- a/lib/nvidia.pm
+++ b/lib/nvidia.pm
@@ -570,15 +570,11 @@ sub nvidia_cgi {
 	push(@tmp, "GPRINT:gpu5:LAST:\\:%3.0lf%%");
 	push(@tmp, "LINE2:gpu8#963C74:Card 8\\g");
 	push(@tmp, "GPRINT:gpu8:LAST:\\:%3.0lf%%\\n");
-	push(@tmpz, "LINE2:gpu0#FFA500:Card 0");
-	push(@tmpz, "LINE2:gpu3#4444EE:Card 3");
-	push(@tmpz, "LINE2:gpu6#EE44EE:Card 6");
-	push(@tmpz, "LINE2:gpu1#44EEEE:Card 1");
-	push(@tmpz, "LINE2:gpu4#448844:Card 4");
-	push(@tmpz, "LINE2:gpu7#EEEE44:Card 7");
-	push(@tmpz, "LINE2:gpu2#44EE44:Card 2");
-	push(@tmpz, "LINE2:gpu5#EE4444:Card 5");
-	push(@tmpz, "LINE2:gpu8#963C74:Card 8");
+        for($n = 0; $n < 9; $n++) {
+                if($n < $nvidia->{max}) {
+                        push(@tmpz, "LINE2:gpu" . $n . $LC[$n] . ":Card $n");
+                }
+        }
 	if(lc($config->{show_gaps}) eq "y") {
 		push(@tmp, "AREA:wrongdata#$colors->{gap}:");
 		push(@tmpz, "AREA:wrongdata#$colors->{gap}:");
@@ -688,15 +684,11 @@ sub nvidia_cgi {
 	push(@tmp, "GPRINT:mem5:LAST:\\:%3.0lf%%");
 	push(@tmp, "LINE2:mem8#963C74:Card 8\\g");
 	push(@tmp, "GPRINT:mem8:LAST:\\:%3.0lf%%\\n");
-	push(@tmpz, "LINE2:mem0#FFA500:Card 0");
-	push(@tmpz, "LINE2:mem3#4444EE:Card 3");
-	push(@tmpz, "LINE2:mem6#EE44EE:Card 6");
-	push(@tmpz, "LINE2:mem1#44EEEE:Card 1");
-	push(@tmpz, "LINE2:mem4#448844:Card 4");
-	push(@tmpz, "LINE2:mem7#EEEE44:Card 7");
-	push(@tmpz, "LINE2:mem2#44EE44:Card 2");
-	push(@tmpz, "LINE2:mem5#EE4444:Card 5");
-	push(@tmpz, "LINE2:mem8#963C74:Card 8");
+        for($n = 0; $n < 9; $n++) {
+                if($n < $nvidia->{max}) {
+                        push(@tmpz, "LINE2:mem" . $n . $LC[$n] . ":Card $n");
+                }
+        }
 	if(lc($config->{show_gaps}) eq "y") {
 		push(@tmp, "AREA:wrongdata#$colors->{gap}:");
 		push(@tmpz, "AREA:wrongdata#$colors->{gap}:");


### PR DESCRIPTION
The legend in NVidia figure was originally sorted as "0,3,6,1,4,7,2,5,8" for both normal display mode and zoomed display mode. In normal mode, the legends are displayed in a 3x3 grid and "0,3,6,1,4,7,2,5,8" will sort the legends in a column-first order. This is good. 
However, in zoom mode, all legends are displayed in one row at the bottom of the figure. The legend should be sorted as "0,1,2,3,4,5,6,7,8". And it should also be good to ignore "Card $n" that does not actually exist in the computer (e.g. it is not necessary to display Card 8 when there is only 4 NVidia card installed).
So following the style of _nvidia1, I modify this hard-coded part in _nvidia2 and _nvidia3 with for loops. This solves the mentioned problem in zoom mode. 

Before:
![old](https://user-images.githubusercontent.com/12756472/30931560-9fb57c36-a3f7-11e7-8201-9b6f2e3982c1.png)


After:
![new](https://user-images.githubusercontent.com/12756472/30931810-5f0643b8-a3f8-11e7-939f-14451a62f3b5.png)


