### PR TITLE
Get temperature for a NVMe

### DIFF
--- a/lib/disk.pm
+++ b/lib/disk.pm
@@ -236,6 +236,11 @@ sub disk_update {
 						$temp = $tmp[3] unless $temp;
 						chomp($temp);
 					}
+					if(/^Temperature: /) {
+                                                my @tmp = split(' ', $_);
+                                                $temp = $tmp[1] unless $temp;
+                                                chomp($temp);
+                                        }
 				}
 				close(IN);
 				if(!$temp) {


### PR DESCRIPTION
Hello,

Do you think it could be ok to get the temperature field value from smartctl -A for a NVMe like this, as the format of the SMART data section differs from HDD or SSD?

For example:
=== START OF SMART DATA SECTION ===
SMART overall-health self-assessment test result: PASSED

SMART/Health Information (NVMe Log 0x02, NSID 0xffffffff)
Critical Warning:                   0x00
Temperature:                        40 Celsius
Available Spare:                    100%
Available Spare Threshold:          10%
Percentage Used:                    0%
Data Units Read:                    1,769,281 [905 GB]
Data Units Written:                 1,384,224 [708 GB]
Host Read Commands:                 24,646,213
Host Write Commands:                19,105,374
Controller Busy Time:               38
Power Cycles:                       32
Power On Hours:                     129
Unsafe Shutdowns:                   6
Media and Data Integrity Errors:    0
Error Information Log Entries:      44

Best  regards,

Arth