### PR TITLE
Update debian.conf with correct mysqld socket path

### DIFF
--- a/docs/debian.conf
+++ b/docs/debian.conf
@@ -8,9 +8,9 @@
 
 <mysql>
 	conn_type = socket
-	list = /var/run/mysqld/mysqld.sock
+	list = /run/mysqld/mysqld.sock
 	<desc>
-		/var/run/mysqld/mysqld.sock = 3306, user, secret
+		/run/mysqld/mysqld.sock = 3306, user, secret
 	</desc>
 </mysql>
 


### PR DESCRIPTION
Checked on Debian 9 and 10 with this command: `sudo find / -type s`

Other references:
- [Difference between /run and /var/run](https://unix.stackexchange.com/questions/175345/difference-between-run-and-var-run)
- [Why has /var/run been migrated to /run?](https://askubuntu.com/questions/57297/why-has-var-run-been-migrated-to-run)