### PR TITLE
Add $local_fs as dependency for init script

### DIFF
--- a/docs/monitorix-deb.init
+++ b/docs/monitorix-deb.init
@@ -2,8 +2,8 @@
 
 ### BEGIN INIT INFO
 # Provides:          monitorix
-# Required-Start:    
-# Required-Stop:     
+# Required-Start:    $local_fs
+# Required-Stop:     $local_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Start Monitorix daemon


### PR DESCRIPTION
Dependency `$local_fs` is missing from the Debian flavored init script whilst present in the Redhat one.

Re-added for consistency and to make sure that local filesystem are mounted before starting monitorix.