### PR TITLE
Add posibility to view the website as web app in full screen mode

### DIFF
--- a/monitorix.cgi
+++ b/monitorix.cgi
@@ -492,6 +492,8 @@ EOF
 	if($config{refresh_rate}) {
 		print("    <meta http-equiv='Refresh' content='" . $config{refresh_rate} . "'>\n");
 	}
+	print("    <meta name='apple-mobile-web-app-capable' content='yes' />\n");
+	print("    <meta name='apple-mobile-web-app-status-bar-style' content='black' />\n");
 	print("  </head>\n");
 	print("  <body>\n");
 	print("  $piwik_code\n");


### PR DESCRIPTION
This enables monitorix to be saved as bookmark on iOS devices and the opened in a web app designed manner (Without the browser toolbars and as separate app). 

To improve the web app feeling one would need to open new pages like the graphs via  event handler like this:

```
function hijack() {
  $('#viewport a').click(function(e){
    e.preventDefault();
    loadPage(e.target.href);
  })
}

function loadPage(url){
  $('#viewport').load(url + '#viewport', hijack);
}
```

But it already works looks quite nice with these two added meta tags.
