### PR TITLE
Add  fan speed, power and percentage identifiers to gensens.

### DIFF
--- a/lib/gensens.pm
+++ b/lib/gensens.pm
@@ -424,7 +424,7 @@ sub gensens_cgi {
 	foreach my $sg (sort keys %{$gensens->{list}}) {
 		my @ls = split(',', $gensens->{list}->{$sg});
 
-		# determine if we are dealing with a 'temp', 'cpu', 'bat', 'pwr', 'fan' or 'pct' graph
+		# determine if we are dealing with a 'temp', 'cpu', 'bat', 'pwr', 'fan', 'pct' or 'byt' graph
 		if(index($ls[0], "temp") == 0) {
 			$vlabel = $temp_scale;
 		} elsif(index($ls[0], "cpu") == 0) {
@@ -437,6 +437,8 @@ sub gensens_cgi {
 			$vlabel = "RPM";
 		} elsif(index($ls[0], "pct") == 0) {
 			$vlabel = "Percent (%)";
+		} elsif(index($ls[0], "byt") == 0) {
+			$vlabel = "bytes";
 		} else {
 			# not supported yet
 		}

--- a/lib/gensens.pm
+++ b/lib/gensens.pm
@@ -424,7 +424,7 @@ sub gensens_cgi {
 	foreach my $sg (sort keys %{$gensens->{list}}) {
 		my @ls = split(',', $gensens->{list}->{$sg});
 
-		# determine if we are dealing with a 'temp', 'cpu', 'bat' or 'pwr' graph
+		# determine if we are dealing with a 'temp', 'cpu', 'bat', 'pwr' or 'fan' graph
 		if(index($ls[0], "temp") == 0) {
 			$vlabel = $temp_scale;
 		} elsif(index($ls[0], "cpu") == 0) {
@@ -433,6 +433,8 @@ sub gensens_cgi {
 			$vlabel = "Charge";
 		} elsif(index($ls[0], "pwr") == 0) {
 			$vlabel = "Watt";
+		} elsif(index($ls[0], "fan") == 0) {
+			$vlabel = "RPM";
 		} else {
 			# not supported yet
 		}

--- a/lib/gensens.pm
+++ b/lib/gensens.pm
@@ -424,7 +424,7 @@ sub gensens_cgi {
 	foreach my $sg (sort keys %{$gensens->{list}}) {
 		my @ls = split(',', $gensens->{list}->{$sg});
 
-		# determine if we are dealing with a 'temp', 'cpu', 'bat', 'pwr' or 'fan' graph
+		# determine if we are dealing with a 'temp', 'cpu', 'bat', 'pwr', 'fan' or 'pct' graph
 		if(index($ls[0], "temp") == 0) {
 			$vlabel = $temp_scale;
 		} elsif(index($ls[0], "cpu") == 0) {
@@ -435,6 +435,8 @@ sub gensens_cgi {
 			$vlabel = "Watt";
 		} elsif(index($ls[0], "fan") == 0) {
 			$vlabel = "RPM";
+		} elsif(index($ls[0], "pct") == 0) {
+			$vlabel = "Percent (%)";
 		} else {
 			# not supported yet
 		}

--- a/lib/gensens.pm
+++ b/lib/gensens.pm
@@ -424,13 +424,15 @@ sub gensens_cgi {
 	foreach my $sg (sort keys %{$gensens->{list}}) {
 		my @ls = split(',', $gensens->{list}->{$sg});
 
-		# determine if we are dealing with a 'temp', 'cpu' or 'bat' graph
+		# determine if we are dealing with a 'temp', 'cpu', 'bat' or 'pwr' graph
 		if(index($ls[0], "temp") == 0) {
 			$vlabel = $temp_scale;
 		} elsif(index($ls[0], "cpu") == 0) {
 			$vlabel = "Hz";
 		} elsif(index($ls[0], "bat") == 0) {
 			$vlabel = "Charge";
+		} elsif(index($ls[0], "pwr") == 0) {
+			$vlabel = "Watt";
 		} else {
 			# not supported yet
 		}


### PR DESCRIPTION
It would be nice to have a bit more options like power draw, fan speed and arbitrary percentage values in the gensens graphs.

This adds:
- Power graph in "Watts" via '`pwr`' identifier
- Fan speed graph in "RPM" via '`fan`' identifier
- Percentage graph in "Percent (%)" via '`pct`' identifier
- Byte graph in "bytes" via 'byt' identifier