### PR TITLE
Add argument usage to cmd option in ambsens.

### DIFF
--- a/lib/ambsens.pm
+++ b/lib/ambsens.pm
@@ -145,11 +145,12 @@ sub ambsens_update {
 		my $e2 = 1;
 		foreach my $dl (split(',', $ambsens->{desc}->{$e})) {
 			my $str = trim($dl);
-			my $script = trim($ambsens->{cmd}->{$str});
+			my $scriptWithArguments = trim($ambsens->{cmd}->{$str});
+			my $script = (split(' ', $scriptWithArguments))[0];
 
 			if($script) {
 				if(-x $script) {
-					my $val = `$script`;
+					my $val = `$scriptWithArguments`;
 					chomp($val);
 					$sens[$e][$e2] = $val;
 

--- a/lib/ambsens.pm
+++ b/lib/ambsens.pm
@@ -145,12 +145,12 @@ sub ambsens_update {
 		my $e2 = 1;
 		foreach my $dl (split(',', $ambsens->{desc}->{$e})) {
 			my $str = trim($dl);
-			my $scriptWithArguments = trim($ambsens->{cmd}->{$str});
-			my $script = (split(' ', $scriptWithArguments))[0];
+			my $script_with_arguments = trim($ambsens->{cmd}->{$str});
+			my $script = (split(' ', $script_with_arguments))[0];
 
 			if($script) {
 				if(-x $script) {
-					my $val = `$scriptWithArguments`;
+					my $val = `$script_with_arguments`;
 					chomp($val);
 					$sens[$e][$e2] = $val;
 


### PR DESCRIPTION
`cmd` in ambsens.pm can now also handle arguments. Nothing else should be affected. Fixes #343