### PR TITLE
Fix smb counter in user.pm in case smb is not installed.

### DIFF
--- a/lib/user.pm
+++ b/lib/user.pm
@@ -144,7 +144,7 @@ sub user_update {
 		}
 	}
 	close(IN);
-	$smb--;
+	$smb-- if $smb > 0;
 
 	open(IN, "macusers 2>/dev/null |");
 	@data = <IN>;


### PR DESCRIPTION
Before the smb value was `-1` if no `smbstatus` was found, resulting in `-nan` values.
Now the behaviour is the same as for macusers.