### PR TITLE
Workaround for memory leak in perl [5.26, 5.34) regex parsing.

### DIFF
--- a/lib/ipmi.pm
+++ b/lib/ipmi.pm
@@ -158,8 +158,19 @@ sub ipmi_update {
 			$str = trim($i);
 			$unit = $ipmi->{units}->{$e};
 			foreach(@data) {
-				if(/^($str)\s+\|\s+(-?\d+\.*\d*)\s+$unit\s+/) {
-					my $val = $2;
+				my $val;
+				if ("$]" >= 5.026 && "$]" < 5.034) {
+					# Memory leak in perl regexp https://github.com/Perl/perl5/issues/17218
+					# Work around by using ASCII-restrict modifier.
+					if(/^($str)\s+\|\s+(-?\d+\.*\d*)\s+$unit\s+/a) {
+						$val = $2;
+					}
+				} else {
+					if(/^($str)\s+\|\s+(-?\d+\.*\d*)\s+$unit\s+/) {
+						$val = $2;
+					}
+				}
+				if(defined $val) {
 					$sens[$e][$e2] = $val;
 
 					# check alerts for each sensor defined


### PR DESCRIPTION
Compatibility fix with perl versions [5.26, 5.34) due to a memory leak in perl (https://github.com/Perl/perl5/issues/17218).
With the ASCII-restrict modifier the memory leak does not affect monitorix.
Fixes #356