### PR TITLE
Fixes a wrong array size check in amdgpu.pm and nvidiagpu.pm

### DIFF
--- a/lib/amdgpu.pm
+++ b/lib/amdgpu.pm
@@ -53,7 +53,7 @@ sub amdgpu_init {
 		# values delimitted by ", " (comma + space)
 		my @gpu_group = split(', ', $amdgpu->{list}->{$k});
 		for(my $n = 0; $n < $max_number_of_gpus; $n++) {
-			if($gpu_group[$n]) {
+			if($n < scalar(@gpu_group)) {
 				my $d = trim($gpu_group[$n]);
 				$d =~ s/^\"//;
 				$d =~ s/\"$//;
@@ -543,7 +543,7 @@ sub amdgpu_cgi {
 				push(@tmp, "COMMENT: \\n");
 			}
 			for($n = 0; $n < $max_number_of_gpus; $n += 1) {
-				if($d[$n]) {
+				if($n < scalar(@d)) {
 					my $dstr = trim($d[$n]);
 					my $base = "";
 					$dstr =~ s/^\"//;
@@ -573,7 +573,7 @@ sub amdgpu_cgi {
 
 					my $value_name = "gpu" . $n . "_val" . $n_sensor;
 					my $value_name2;
-					push(@tmp, "LINE2:trans_" . $value_name . $LC[$n] . ":$str" . ($n_plot < $main_sensor_plots ? "" : ( $show_current_values ? "\\: \\g" : (($n%2 || !$d[$n+1]) ? "\\n" : ""))));
+					push(@tmp, "LINE2:trans_" . $value_name . $LC[$n] . ":$str" . ($n_plot < $main_sensor_plots ? "" : ( $show_current_values ? "\\: \\g" : (($n%2 || ($n+1 == scalar(@d))) ? "\\n" : ""))));
 					push(@tmpz, "LINE2:trans_" . $value_name . $LC[$n] . ":$dstr");
 
 					if ($n_sensor2) {
@@ -612,7 +612,7 @@ sub amdgpu_cgi {
 									push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:" . $legend_labels_per_sensor[$n_sensor] . "\\g");
 									push(@tmp, "GPRINT:trans_" . $value_name2 . ":LAST: /" . $legend_labels_per_sensor[$n_sensor2] . " (actual/limit)\\n");
 								} else {
-									push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:" . $legend_labels_per_sensor[$n_sensor] . (($n%2 || !$d[$n+1]) ? "\\n" : ""));
+									push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:" . $legend_labels_per_sensor[$n_sensor] . (($n%2 || ($n+1 == scalar(@d))) ? "\\n" : ""));
 								}
 							}
 						}

--- a/lib/nvidiagpu.pm
+++ b/lib/nvidiagpu.pm
@@ -182,8 +182,8 @@ sub nvidiagpu_update {
 		for($n = 0; $n < $max_number_of_gpus; $n++) {
 			@sensors = ($use_nan_for_missing_data ? (0+"nan") : 0) x $number_of_values_per_gpu_in_rrd;
 
-			if($gpu_group[$n]) {
-        my $str = trim($gpu_group[$n] || "");
+			if($n < scalar(@gpu_group)) {
+				my $str = trim($gpu_group[$n]);
 
         open(IN, "nvidia-smi --format=csv,noheader,nounits -i $str --query-gpu=clocks.current.graphics,clocks.current.memory,utilization.gpu,utilization.memory,temperature.gpu,temperature.memory,fan.speed,pstate,power.draw,power.limit,memory.used,memory.total |");
 				while(<IN>) {
@@ -512,7 +512,7 @@ sub nvidiagpu_cgi {
 				push(@tmp, "COMMENT: \\n");
 			}
 			for($n = 0; $n < $max_number_of_gpus; $n += 1) {
-				if($d[$n]) {
+				if($n < scalar(@d)) {
 					my $dstr = trim($d[$n]);
 					my $base = "";
 					$dstr =~ s/^\"//;
@@ -542,7 +542,7 @@ sub nvidiagpu_cgi {
 
 					my $value_name = "gpu" . $n . "_val" . $n_sensor;
 					my $value_name2;
-					push(@tmp, "LINE2:trans_" . $value_name . $LC[$n] . ":$str" . ($n_plot < $main_sensor_plots ? "" : ( $show_current_values ? "\\: \\g" : (($n%2 || !$d[$n+1]) ? "\\n" : ""))));
+					push(@tmp, "LINE2:trans_" . $value_name . $LC[$n] . ":$str" . ($n_plot < $main_sensor_plots ? "" : ( $show_current_values ? "\\: \\g" : (($n%2 || ($n+1 == scalar(@d))) ? "\\n" : ""))));
 					push(@tmpz, "LINE2:trans_" . $value_name . $LC[$n] . ":$dstr");
 
 					if ($n_sensor2) {
@@ -566,7 +566,7 @@ sub nvidiagpu_cgi {
 								push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:" . $legend_labels_per_sensor[$n_sensor] . "\\g");
 								push(@tmp, "GPRINT:trans_" . $value_name2 . ":LAST: /" . $legend_labels_per_sensor[$n_sensor2] . " (actual/limit)\\n");
 							} else {
-								push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:" . $legend_labels_per_sensor[$n_sensor] . (($n%2 || !$d[$n+1]) ? "\\n" : ""));
+								push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:" . $legend_labels_per_sensor[$n_sensor] . (($n%2 || ($n+1 == scalar(@d))) ? "\\n" : ""));
 							}
 						}
 					}


### PR DESCRIPTION
Sorry for the regression. But I just noticed that and nvidia card with ID 0 is not recognised due to a wrong check valid array values.

It was wrong to check the end of an array by looking at its content and see if it is valid. A `"0"` will of course be used as invalid array entry. 

Replaced this usage in nvidiagpu.pm (and also amgpu.pm) by comparing indices with the size directly.