### PR TITLE
Add additional_graph_name config option.

### DIFF
--- a/man/man5/monitorix.conf.5
+++ b/man/man5/monitorix.conf.5
@@ -180,6 +180,13 @@ All the configuration files in there will be loaded in alphabetic order, so the 
 Default value: \fI/etc/monitorix/conf.d\fP
 .RE
 .P
+.BI additional_graph_name
+.RS
+This is an optional configuration option for configuration files in \fIinclude_dir\fP. It takes a comma separated list of additional modules that is appended to the \fIgraph_name\fP option. This enables you to add custom modules without changing the \fImonitorix.conf\fP or copy all names from \fIgraph_name\fP to your config file.
+.P
+Default value: \fINone\fP
+.RE
+.P
 .BI ip_default_table
 .RS
 This option will define in which table Monitorix will put all \fIiptables\fP rules for network traffic accounting monitoring. It only works on Linux.

--- a/monitorix
+++ b/monitorix
@@ -607,7 +607,11 @@ if($config{include_dir} && opendir(DIR, $config{include_dir})) {
 			#	delete $config_inc{$key};
 			#	next;
 			#}
-
+			if($key eq "additional_graph_name") {
+				$config{graph_name} .= ", $val";
+				delete $config_inc{$key};
+				next;
+			}
 			# one level options
 			$config{$key} = $val;
 			delete $config_inc{$key};

--- a/monitorix.cgi
+++ b/monitorix.cgi
@@ -295,7 +295,11 @@ if($config{include_dir} && opendir(DIR, $config{include_dir})) {
 			#	delete $config_inc{graph_name};
 			#	next;
 			#}
-
+			if($key eq "additional_graph_name") {
+				$config{graph_name} .= ", $val";
+				delete $config_inc{$key};
+				next;
+			}
 			# one level options
 			$config{$key} = $val;
 			delete $config_inc{$key};


### PR DESCRIPTION
This is an optional configuration option for configuration files in `include_dir`. It takes a comma separated list of additional modules that is appended to the `graph_name` option. 

This enables you to add custom modules without changing the `monitorix.conf` or copy all names from `graph_name` to your config file which is quite nice when developing new modules.