### PR TITLE
Add support to rename ipmi sensors with whitespaces in their name.

### DIFF
--- a/lib/ipmi.pm
+++ b/lib/ipmi.pm
@@ -364,6 +364,7 @@ sub ipmi_cgi {
 		}
 	}
 
+	my $whitespace_key_support = lc($ipmi->{whitespace_key_support} || "") eq "y" ? 1 : 0;
 	$n = 0;
 	while($n < scalar(my @sl = split(',', $ipmi->{list}))) {
 		if($title) {
@@ -385,6 +386,9 @@ sub ipmi_cgi {
 			my $unit = $ipmi->{units}->{$n};
 			foreach my $i (split(',', $ipmi->{desc}->{$n})) {
 				$i = trim($i);
+				if ($whitespace_key_support) {
+					$i=~s/ /_/g;
+				}
 				$str = $ipmi->{map}->{$i} || $i;
 				$str = sprintf("%-40s", substr($str, 0, 40));
 				push(@tmp, "LINE2:s" . ($e + 1) . $LC[$e] . ":$str");

--- a/man/man5/monitorix.conf.5
+++ b/man/man5/monitorix.conf.5
@@ -1173,7 +1173,7 @@ This is the type of sensor in each group. It's important to not mix different ty
 .P
 .BI map
 .RS
-This list complements the \fBdesc\fP option. It basically allows you to change the name that will appear in the graph, hiding the real name of the sensor. If no association is defined, then Monitorix will display the name specified in the \fBdesc\fP option. Note, this only works in names that don't include whitespaces.
+This list complements the \fBdesc\fP option. It basically allows you to change the name that will appear in the graph, hiding the real name of the sensor. If no association is defined, then Monitorix will display the name specified in the \fBdesc\fP option. Note, this only works in names that don't include whitespaces unless you use the \fBwhitespace_key_support\fP option and replace whitespaces with underscores in the key.
 .RE
 .P
 .BI alerts
@@ -1214,6 +1214,12 @@ The external script will receive the following arguments:
 3rd - the value of the sensor.
 .P
 .RE
+.RE
+.BI whitespace_key_support
+.RS
+This list complements the \fBmap\fP option. It changes the handling of the key names. Without this option enabled you can't rename keys with whitespaces using the \fBmap\fP option. When enabled, whitespaces in the map key will be replaced by underscores(_) and enables you to specify the key names this way.
+.P
+Default value: \fIn\fP
 .RE
 .BI graphs_per_row
 .RS


### PR DESCRIPTION
By setting the new config option `whitespace_key_support = y` in ipmi.pm you can now rename also sensors containing white spaces via `map`. The whitespace is just converted to an underscore.
By default `whitespace_key_support` is disabled to not change existing behaviour. 