### PR TITLE
Add rrd locking option

### DIFF
--- a/lib/Monitorix.pm
+++ b/lib/Monitorix.pm
@@ -515,7 +515,7 @@ sub flush_accounting_rules {
 sub lockfile_handler {
 	my ($config) = @_;
 	if (lc($config->{enable_rrd_lock} || "") eq "y") {
-		my $lock_file = "/tmp/monitorix.flock";
+		my $lock_file = "/tmp/monitorix.lock";
 
 		my $lockfile_was_available = (-e $lock_file);
 		open(my $fh, ">>", $lock_file) or die "Can't open $lock_file: $!";

--- a/lib/Monitorix.pm
+++ b/lib/Monitorix.pm
@@ -518,7 +518,7 @@ sub lockfile_handler {
 		my $lock_file = "/tmp/monitorix.lock";
 
 		my $lockfile_was_available = (-e $lock_file);
-		open(my $fh, ">>", $lock_file) or die "Can't open $lock_file: $!";
+		open(my $fh, ($lockfile_was_available ? "+<" : ">>"), $lock_file) or die "Can't open $lock_file: $!"; # If the file already exists we open it without the O_CREATE flag due to the limitations introduced by fs.protected_regular.
 		if (!$lockfile_was_available) {
 			chmod(0666, $lock_file);
 		}

--- a/lib/Monitorix.pm
+++ b/lib/Monitorix.pm
@@ -24,8 +24,9 @@ use strict;
 use warnings;
 use Exporter 'import';
 use POSIX qw(setuid setgid setsid getgid getuid ceil);
+use Fcntl qw(:flock);
 use Socket;
-our @EXPORT = qw(logger trim min max celsius_to img_element picz_a_element picz_js_a_element uptime2str setup_riglim httpd_setup get_nvidia_data get_ati_data flush_accounting_rules);
+our @EXPORT = qw(logger trim min max celsius_to img_element picz_a_element picz_js_a_element uptime2str setup_riglim httpd_setup get_nvidia_data get_ati_data flush_accounting_rules lockfile_handler global_flock);
 
 sub logger {
 	my ($msg) = @_;
@@ -508,6 +509,28 @@ sub flush_accounting_rules {
 		logger("Flushing out ipfw rules.") if $debug;
 		system("ipfw delete $config->{port}->{rule} 2>/dev/null");
 		system("ipfw delete $config->{nginx}->{rule} 2>/dev/null");
+	}
+}
+
+sub lockfile_handler {
+	my ($config) = @_;
+	if (lc($config->{enable_rrd_lock} || "") eq "y") {
+		my $lock_file = "/tmp/monitorix.flock";
+
+		my $lockfile_was_available = (-e $lock_file);
+		open(my $fh, ">>", $lock_file) or die "Can't open $lock_file: $!";
+		if (!$lockfile_was_available) {
+			chmod(0666, $lock_file);
+		}
+		return $fh;
+	}
+	return undef;
+}
+
+sub global_flock {
+	my ($fh, $option) = @_;
+	if (defined($fh)) {
+		flock($fh, $option) or die "flock error: $!\n";
 	}
 }
 

--- a/man/man5/monitorix.conf.5
+++ b/man/man5/monitorix.conf.5
@@ -169,6 +169,13 @@ This option will fork an independent process for each graph in order to speed up
 Default value: \fIy\fP
 .RE
 .P
+.BI enable_rrd_lock
+.RS
+This option will synchronise the rrd file access by creating the file \fI/tmp/monitorix.lock\fP and use it via flock.
+.P
+Default value: \fIn\fP
+.RE
+.P
 .BI include_dir
 .RS
 The main configuration file is usually called \fImonitorix.conf\fP and its location is provided as part of the command line arguments. In addition, other configuration files may be loaded placing them in the directory pointed by this option. The names must end with .conf to be included.

--- a/monitorix
+++ b/monitorix
@@ -31,6 +31,7 @@ use POSIX qw(WNOHANG LC_TIME setlocale uname pause setsid);
 use Config::General;
 use Getopt::Std;
 use Cwd qw(abs_path);
+use Fcntl qw(:flock);
 
 # Force a standard locale
 $ENV{LANG} = "";
@@ -767,6 +768,8 @@ while(1) {
 
 	# call to all enabled graphs on every minute
 	if($sec == 0) {
+		my $lockfile_handler = lockfile_handler(\%config);
+		global_flock($lockfile_handler, LOCK_SH);
 		foreach my $f (@{$config{func_update}}) {
 			my $update = $f . "_update";
 			my $d = $f;
@@ -785,6 +788,7 @@ while(1) {
 				}
 			}
 		}
+		global_flock($lockfile_handler, LOCK_UN);
 
 		# TRAFFACCT graph daily reports
 		if(lc($config{traffacct}->{enabled} || "") eq "y") {
@@ -828,6 +832,7 @@ while(1) {
 					next;
 				}
 
+				global_flock($lockfile_handler, LOCK_SH);
 				# daily
 				if(lc($emailreports->{daily}->{enabled} || "") eq "y") {
 					eval { emailreports::emailreports_send(\%config, "daily", "1day", $d); };
@@ -865,6 +870,7 @@ while(1) {
 						}
 					}
 				}
+				global_flock($lockfile_handler, LOCK_UN);
 			}
 		}
 

--- a/monitorix
+++ b/monitorix
@@ -769,7 +769,7 @@ while(1) {
 	# call to all enabled graphs on every minute
 	if($sec == 0) {
 		my $lockfile_handler = lockfile_handler(\%config);
-		global_flock($lockfile_handler, LOCK_SH);
+		global_flock($lockfile_handler, LOCK_EX);
 		foreach my $f (@{$config{func_update}}) {
 			my $update = $f . "_update";
 			my $d = $f;
@@ -832,7 +832,6 @@ while(1) {
 					next;
 				}
 
-				global_flock($lockfile_handler, LOCK_SH);
 				# daily
 				if(lc($emailreports->{daily}->{enabled} || "") eq "y") {
 					eval { emailreports::emailreports_send(\%config, "daily", "1day", $d); };
@@ -870,7 +869,6 @@ while(1) {
 						}
 					}
 				}
-				global_flock($lockfile_handler, LOCK_UN);
 			}
 		}
 

--- a/monitorix.cgi
+++ b/monitorix.cgi
@@ -31,6 +31,7 @@ use Config::General;
 use POSIX;
 use RRDs;
 use Encode;
+use Fcntl qw(:flock);
 
 my %config;
 my %cgi;
@@ -577,6 +578,8 @@ if($mode eq "localhost") {
 	my @writers;	# array of file descriptors
 	my $children = 0;
 
+	my $lockfile_handler = lockfile_handler(\%config);
+	global_flock($lockfile_handler, LOCK_SH);
 	foreach (split(',', $config{graph_name})) {
 		my $gn = trim($_);
 		my $g = "";
@@ -652,6 +655,7 @@ if($mode eq "localhost") {
 			print @{$outputs{$n}} if $outputs{$n};
 		}
 	}
+	global_flock($lockfile_handler, LOCK_UN);
 
 } elsif($mode eq "multihost") {
 	multihost(\%config, \%colors, \%cgi);

--- a/monitorix.conf
+++ b/monitorix.conf
@@ -19,6 +19,7 @@ max_historic_years = 1
 accept_selfsigned_certs = y
 image_format = PNG
 enable_parallelizing = y
+enable_rrd_lock = n
 include_dir = /etc/monitorix/conf.d
 
 base_dir = /var/lib/monitorix/www/


### PR DESCRIPTION
This is a proposal for synchronised rrd access and should fix issue #370:

- It adds an enable_rrd_lock config option to enable it.
- Creates a lock file and uses it via flock when reading and writing rrd files.

Testing is still ongoing to see if it really fixes the locking issue but I would like to test it for a few days.

Three open questions with this PR:
- I am not really sure what happens on crashes. Can we assume that flock unlocks correctly when the file handler goes out of scope or some signal interrupts? Or do we need to unlock the lockfile via a signal handler to make sure the file is unlocked? In perl I am not sure what is guaranteed to happen on a crash/interrupt.
- At the moment the file permissions are only set if the file didn't exist before. So we are not guarded agains the file being already existent and having the wrong permissions. Would it be better to always check the permissions? I wanted to keep that check simple as it is performed every time so I check only its existence at the moment.
- How to name the lock file? `monitorix.lock`, `monitorix.flock` or something else? At the moment the documentation and source do not match.