### PR TITLE
Fix legend alignment in nvidiagpu and amdgpu.

### DIFF
--- a/lib/amdgpu.pm
+++ b/lib/amdgpu.pm
@@ -478,10 +478,10 @@ sub amdgpu_cgi {
 		"%4.2lf%s",
 		"%5.0lf%s",
 		"%5.0lf%s",
-		"%3.1lf%%",
-		"%3.1lf",
-		"%3.1lf",
-		"%3.1lf"
+		"%5.1lf%%",
+		"%5.1lf",
+		"%5.1lf",
+		"%5.1lf"
 	);
 
 	my @graphs_per_plot = (7, 8, 10, 9, [5, 6], 0, 1, 2, 3, 4); # To rearange the graphs
@@ -597,12 +597,12 @@ sub amdgpu_cgi {
 							push(@tmp, "COMMENT:      N/A\\n");
 						} else {
 							if($main_plots_with_average[$n_plot]) {
-								push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:  Current\\: " . $legend_labels_per_sensor[$n_sensor]);
-								push(@tmp, "GPRINT:trans_" . $value_name . ":AVERAGE:  Average\\: " . $legend_labels_per_sensor[$n_sensor]);
-								push(@tmp, "GPRINT:trans_" . $value_name . ":MIN:  Min\\: " . $legend_labels_per_sensor[$n_sensor]);
-								push(@tmp, "GPRINT:trans_" . $value_name . ":MAX:  Max\\: " . $legend_labels_per_sensor[$n_sensor] . "\\n");
+								push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:  Current\\:" . $legend_labels_per_sensor[$n_sensor]);
+								push(@tmp, "GPRINT:trans_" . $value_name . ":AVERAGE: Average\\:" . $legend_labels_per_sensor[$n_sensor]);
+								push(@tmp, "GPRINT:trans_" . $value_name . ":MIN: Min\\:" . $legend_labels_per_sensor[$n_sensor]);
+								push(@tmp, "GPRINT:trans_" . $value_name . ":MAX: Max\\:" . $legend_labels_per_sensor[$n_sensor] . "\\n");
 							} else {
-								push(@tmp, "GPRINT:trans_" . $value_name . ":LAST: Current\\: " . $legend_labels_per_sensor[$n_sensor] . "\\n");
+								push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:  Current\\:" . $legend_labels_per_sensor[$n_sensor] . "\\n");
 							}
 						}
 					} else {

--- a/lib/nvidiagpu.pm
+++ b/lib/nvidiagpu.pm
@@ -444,13 +444,13 @@ sub nvidiagpu_cgi {
 		"%4.2lf%s",
 		"%3.0lf%%",
 		"%3.0lf%%",
-		"%3.1lf",
-		"%3.1lf",
-		"%3.1lf%%",
+		"%5.1lf",
+		"%5.1lf",
+		"%5.1lf%%",
 		"%1.0lf",
 		"%5.0lf%s",
 		"%5.0lf%s",
-		"%3.1lf%%"
+		"%5.1lf%%"
 	);
 
 	my @graphs_per_plot = (6, 4, 5, 10, [8, 9], 2, 3, 0, 1, 7); # To rearange the graphs
@@ -555,12 +555,12 @@ sub nvidiagpu_cgi {
 
 					if($n_plot < $main_sensor_plots) {
 						if($main_plots_with_average[$n_plot]) {
-							push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:  Current\\: " . $legend_labels_per_sensor[$n_sensor]);
-							push(@tmp, "GPRINT:trans_" . $value_name . ":AVERAGE:  Average\\: " . $legend_labels_per_sensor[$n_sensor]);
-							push(@tmp, "GPRINT:trans_" . $value_name . ":MIN:  Min\\: " . $legend_labels_per_sensor[$n_sensor]);
-							push(@tmp, "GPRINT:trans_" . $value_name . ":MAX:  Max\\: " . $legend_labels_per_sensor[$n_sensor] . "\\n");
+							push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:  Current\\:" . $legend_labels_per_sensor[$n_sensor]);
+							push(@tmp, "GPRINT:trans_" . $value_name . ":AVERAGE: Average\\:" . $legend_labels_per_sensor[$n_sensor]);
+							push(@tmp, "GPRINT:trans_" . $value_name . ":MIN: Min\\:" . $legend_labels_per_sensor[$n_sensor]);
+							push(@tmp, "GPRINT:trans_" . $value_name . ":MAX: Max\\:" . $legend_labels_per_sensor[$n_sensor] . "\\n");
 						} else {
-							push(@tmp, "GPRINT:trans_" . $value_name . ":LAST: Current\\: " . $legend_labels_per_sensor[$n_sensor] . "\\n");
+							push(@tmp, "GPRINT:trans_" . $value_name . ":LAST:  Current\\: " . $legend_labels_per_sensor[$n_sensor] . "\\n");
 						}
 					} else {
 						if($show_current_values) {


### PR DESCRIPTION
Fixes the legend alignments in amdgpu and nvidiagpu modules.

Example old:
<img width="722" alt="Bildschirmfoto 2022-03-10 um 14 18 32" src="https://user-images.githubusercontent.com/62039342/157671341-d3f6e23c-9b04-4816-a229-21f418c0db47.png">

Example new:
<img width="720" alt="Bildschirmfoto 2022-03-10 um 14 22 15" src="https://user-images.githubusercontent.com/62039342/157671403-bbcef59c-46be-4aff-96d7-c5bc8fc9e387.png">