### PR TITLE
Missing gaps on nan

### DIFF
--- a/lib/du.pm
+++ b/lib/du.pm
@@ -296,6 +296,7 @@ sub du_cgi {
 	}
 
 	$title = !$silent ? $title : "";
+	my $gap_on_all_nan = lc($du->{gap_on_all_nan} || "") eq "y" ? 1 : 0;
 	my @disk_list = split(',', $du->{list});
 
 	# text mode
@@ -447,7 +448,7 @@ sub du_cgi {
 				push(@DEF0, "DEF:d7=$rrd:du" . $n . "_d7:AVERAGE");
 				push(@DEF0, "DEF:d8=$rrd:du" . $n . "_d8:AVERAGE");
 				push(@DEF0, "DEF:d9=$rrd:du" . $n . "_d9:AVERAGE");
-				push(@CDEF0, "CDEF:allvalues=d1,d2,d3,d4,d5,d6,d7,d8,d9,+,+,+,+,+,+,+,+");
+				push(@CDEF0, ($gap_on_all_nan ? "CDEF:allvalues=d1,UN,0,1,IF,d2,UN,0,1,IF,d3,UN,0,1,IF,d4,UN,0,1,IF,d5,UN,0,1,IF,d6,UN,0,1,IF,d7,UN,0,1,IF,d8,UN,0,1,IF,d9,UN,0,1,IF,+,+,+,+,+,+,+,+,0,GT,1,UNKN,IF" : "CDEF:allvalues=d1,d2,d3,d4,d5,d6,d7,d8,d9,+,+,+,+,+,+,+,+"));
 			# default type is 'bytes'
 			} else {
 				$type_label = "bytes";
@@ -460,7 +461,7 @@ sub du_cgi {
 				push(@DEF0, "DEF:dk7=$rrd:du" . $n . "_d7:AVERAGE");
 				push(@DEF0, "DEF:dk8=$rrd:du" . $n . "_d8:AVERAGE");
 				push(@DEF0, "DEF:dk9=$rrd:du" . $n . "_d9:AVERAGE");
-				push(@CDEF0, "CDEF:allvalues=dk1,dk2,dk3,dk4,dk5,dk6,dk7,dk8,dk9,+,+,+,+,+,+,+,+");
+				push(@CDEF0, ($gap_on_all_nan ? "CDEF:allvalues=dk1,UN,0,1,IF,dk2,UN,0,1,IF,dk3,UN,0,1,IF,dk4,UN,0,1,IF,dk5,UN,0,1,IF,dk6,UN,0,1,IF,dk7,UN,0,1,IF,dk8,UN,0,1,IF,dk9,UN,0,1,IF,+,+,+,+,+,+,+,+,0,GT,1,UNKN,IF" : "CDEF:allvalues=dk1,dk2,dk3,dk4,dk5,dk6,dk7,dk8,dk9,+,+,+,+,+,+,+,+"));
 				push(@CDEF0, "CDEF:d1=dk1,1024,*");
 				push(@CDEF0, "CDEF:d2=dk2,1024,*");
 				push(@CDEF0, "CDEF:d3=dk3,1024,*");

--- a/lib/fs.pm
+++ b/lib/fs.pm
@@ -890,7 +890,7 @@ sub fs_cgi {
 	}
 
 	$title = !$silent ? $title : "";
-
+	my $gap_on_all_nan = lc($fs->{gap_on_all_nan} || "") eq "y" ? 1 : 0;
 
 	# text mode
 	#
@@ -1036,6 +1036,7 @@ sub fs_cgi {
 			($width, $height) = split('x', $config->{graph_size}->{main}) if $silent eq "imagetagbig";
 			@tmp = @tmpz;
 		}
+		my $cdef_allvalues_fs = $gap_on_all_nan ? "CDEF:allvalues=fs0,UN,0,1,IF,fs1,UN,0,1,IF,fs2,UN,0,1,IF,fs3,UN,0,1,IF,fs4,UN,0,1,IF,fs5,UN,0,1,IF,fs6,UN,0,1,IF,fs7,UN,0,1,IF,+,+,+,+,+,+,+,0,GT,1,UNKN,IF" : "CDEF:allvalues=fs0,fs1,fs2,fs3,fs4,fs5,fs6,fs7,+,+,+,+,+,+,+";
 		$pic = $rrd{$version}->("$IMG_DIR" . "$IMG[$e * 4]",
 			"--title=$config->{graphs}->{_fs1}  ($tf->{nwhen}$tf->{twhen})",
 			"--start=-$tf->{nwhen}$tf->{twhen}",
@@ -1056,7 +1057,7 @@ sub fs_cgi {
 			"DEF:fs5=$rrd:fs" . $e . "_use5:AVERAGE",
 			"DEF:fs6=$rrd:fs" . $e . "_use6:AVERAGE",
 			"DEF:fs7=$rrd:fs" . $e . "_use7:AVERAGE",
-			"CDEF:allvalues=fs0,fs1,fs2,fs3,fs4,fs5,fs6,fs7,+,+,+,+,+,+,+",
+			$cdef_allvalues_fs,
 			@CDEF,
 			@tmp);
 		$err = RRDs::error;
@@ -1084,7 +1085,7 @@ sub fs_cgi {
 				"DEF:fs5=$rrd:fs" . $e . "_use5:AVERAGE",
 				"DEF:fs6=$rrd:fs" . $e . "_use6:AVERAGE",
 				"DEF:fs7=$rrd:fs" . $e . "_use7:AVERAGE",
-				"CDEF:allvalues=fs0,fs1,fs2,fs3,fs4,fs5,fs6,fs7,+,+,+,+,+,+,+",
+				$cdef_allvalues_fs,
 				@CDEF,
 				@tmpz);
 			$err = RRDs::error;
@@ -1155,6 +1156,7 @@ sub fs_cgi {
 			push(@tmp, "COMMENT: \\n");
 			push(@tmp, "COMMENT: \\n");
 		}
+		my $cdef_allvalues_ioa = $gap_on_all_nan ? "CDEF:allvalues=ioa0,UN,0,1,IF,ioa1,UN,0,1,IF,ioa2,UN,0,1,IF,ioa3,UN,0,1,IF,ioa4,UN,0,1,IF,ioa5,UN,0,1,IF,ioa6,UN,0,1,IF,ioa7,UN,0,1,IF,+,+,+,+,+,+,+,0,GT,1,UNKN,IF" : "CDEF:allvalues=ioa0,ioa1,ioa2,ioa3,ioa4,ioa5,ioa6,ioa7,+,+,+,+,+,+,+";
 		$pic = $rrd{$version}->("$IMG_DIR" . "$IMG[$e * 4 + 1]",
 			"--title=$config->{graphs}->{_fs2}  ($tf->{nwhen}$tf->{twhen})",
 			"--start=-$tf->{nwhen}$tf->{twhen}",
@@ -1175,7 +1177,7 @@ sub fs_cgi {
 			"DEF:ioa5=$rrd:fs" . $e . "_ioa5:AVERAGE",
 			"DEF:ioa6=$rrd:fs" . $e . "_ioa6:AVERAGE",
 			"DEF:ioa7=$rrd:fs" . $e . "_ioa7:AVERAGE",
-			"CDEF:allvalues=ioa0,ioa1,ioa2,ioa3,ioa4,ioa5,ioa6,ioa7,+,+,+,+,+,+,+",
+			$cdef_allvalues_ioa,
 			@CDEF,
 			@tmp);
 		$err = RRDs::error;
@@ -1203,7 +1205,7 @@ sub fs_cgi {
 				"DEF:ioa5=$rrd:fs" . $e . "_ioa5:AVERAGE",
 				"DEF:ioa6=$rrd:fs" . $e . "_ioa6:AVERAGE",
 				"DEF:ioa7=$rrd:fs" . $e . "_ioa7:AVERAGE",
-				"CDEF:allvalues=ioa0,ioa1,ioa2,ioa3,ioa4,ioa5,ioa6,ioa7,+,+,+,+,+,+,+",
+				$cdef_allvalues_ioa,
 				@CDEF,
 				@tmpz);
 			$err = RRDs::error;
@@ -1271,6 +1273,7 @@ sub fs_cgi {
 			($width, $height) = split('x', $config->{graph_size}->{main}) if $silent eq "imagetagbig";
 			@tmp = @tmpz;
 		}
+		my $cdef_allvalues_ino = $gap_on_all_nan ? "CDEF:allvalues=fs0,UN,0,1,IF,fs1,UN,0,1,IF,fs2,UN,0,1,IF,fs3,UN,0,1,IF,fs4,UN,0,1,IF,fs5,UN,0,1,IF,fs6,UN,0,1,IF,fs7,UN,0,1,IF,+,+,+,+,+,+,+,0,GT,1,UNKN,IF" : "CDEF:allvalues=fs0,fs1,fs2,fs3,fs4,fs5,fs6,fs7,+,+,+,+,+,+,+";
 		$pic = $rrd{$version}->("$IMG_DIR" . "$IMG[$e * 4 + 2]",
 			"--title=$config->{graphs}->{_fs3}  ($tf->{nwhen}$tf->{twhen})",
 			"--start=-$tf->{nwhen}$tf->{twhen}",
@@ -1291,7 +1294,7 @@ sub fs_cgi {
 			"DEF:fs5=$rrd:fs" . $e . "_ino5:AVERAGE",
 			"DEF:fs6=$rrd:fs" . $e . "_ino6:AVERAGE",
 			"DEF:fs7=$rrd:fs" . $e . "_ino7:AVERAGE",
-			"CDEF:allvalues=fs0,fs1,fs2,fs3,fs4,fs5,fs6,fs7,+,+,+,+,+,+,+",
+			$cdef_allvalues_ino,
 			@CDEF,
 			@tmp);
 		$err = RRDs::error;
@@ -1319,7 +1322,7 @@ sub fs_cgi {
 				"DEF:fs5=$rrd:fs" . $e . "_ino5:AVERAGE",
 				"DEF:fs6=$rrd:fs" . $e . "_ino6:AVERAGE",
 				"DEF:fs7=$rrd:fs" . $e . "_ino7:AVERAGE",
-				"CDEF:allvalues=fs0,fs1,fs2,fs3,fs4,fs5,fs6,fs7,+,+,+,+,+,+,+",
+				$cdef_allvalues_ino,
 				@CDEF,
 				@tmpz);
 			$err = RRDs::error;
@@ -1425,6 +1428,7 @@ sub fs_cgi {
 			push(@tmp, "COMMENT: \\n");
 			push(@tmp, "COMMENT: \\n");
 		}
+		my $cdef_allvalues_tim = $gap_on_all_nan ? "CDEF:allvalues=tim0,UN,0,1,IF,tim1,UN,0,1,IF,tim2,UN,0,1,IF,tim3,UN,0,1,IF,tim4,UN,0,1,IF,tim5,UN,0,1,IF,tim6,UN,0,1,IF,tim7,UN,0,1,IF,+,+,+,+,+,+,+,0,GT,1,UNKN,IF" : "CDEF:allvalues=tim0,tim1,tim2,tim3,tim4,tim5,tim6,tim7,+,+,+,+,+,+,+";
 		$pic = $rrd{$version}->("$IMG_DIR" . "$IMG[$e * 4 + 3]",
 			"--title=$graph_title",
 			"--start=-$tf->{nwhen}$tf->{twhen}",
@@ -1445,7 +1449,7 @@ sub fs_cgi {
 			"DEF:tim5=$rrd:fs" . $e . "_tim5:AVERAGE",
 			"DEF:tim6=$rrd:fs" . $e . "_tim6:AVERAGE",
 			"DEF:tim7=$rrd:fs" . $e . "_tim7:AVERAGE",
-			"CDEF:allvalues=tim0,tim1,tim2,tim3,tim4,tim5,tim6,tim7,+,+,+,+,+,+,+",
+			$cdef_allvalues_tim,
 			"CDEF:stim0=tim0,1000,/",
 			"CDEF:stim1=tim1,1000,/",
 			"CDEF:stim2=tim2,1000,/",
@@ -1481,7 +1485,7 @@ sub fs_cgi {
 				"DEF:tim5=$rrd:fs" . $e . "_tim5:AVERAGE",
 				"DEF:tim6=$rrd:fs" . $e . "_tim6:AVERAGE",
 				"DEF:tim7=$rrd:fs" . $e . "_tim7:AVERAGE",
-				"CDEF:allvalues=tim0,tim1,tim2,tim3,tim4,tim5,tim6,tim7,+,+,+,+,+,+,+",
+				$cdef_allvalues_tim,
 				"CDEF:stim0=tim0,1000,/",
 				"CDEF:stim1=tim1,1000,/",
 				"CDEF:stim2=tim2,1000,/",

--- a/man/man5/monitorix.conf.5
+++ b/man/man5/monitorix.conf.5
@@ -2706,6 +2706,13 @@ This option, when enabled via \fIy\fP, shows \fInan\fP values for missing data i
 .P
 Default value: \fIn\fP
 .RE
+.P
+.BI gap_on_all_nan
+.RS
+This option, when enabled via \fIy\fP, combined with the \fIshow_gaps\fP option shows gaps only if all data points are \fInan\fP instead of requiring only one to be \fInan\fP for a gap. This can be useful if not all sensor data are required for normal operation.
+.P
+Default value: \fIn\fP
+.RE
 .SS ZFS statistics (zfs.pm)
 This graph is able to monitor an unlimited number of pools.
 .P

--- a/man/man5/monitorix.conf.5
+++ b/man/man5/monitorix.conf.5
@@ -2816,6 +2816,13 @@ This option, when enabled via \fIy\fP, shows \fInan\fP values for missing data i
 .P
 Default value: \fIn\fP
 .RE
+.P
+.BI gap_on_all_nan
+.RS
+This option, when enabled via \fIy\fP, combined with the \fIshow_gaps\fP option shows gaps only if all data points are \fInan\fP instead of requiring only one to be \fInan\fP for a gap. This can be useful if not all sensor data are required for normal operation.
+.P
+Default value: \fIn\fP
+.RE
 .SS Network traffic and usage (net.pm)
 .P
 .BI max


### PR DESCRIPTION
The `fs` and `du` module had already the `use_nan_for_missing_data` option but missed the `gap_on_all_nan` option to also use `show_gaps` in a useful way.