### PR TITLE
Fix warning for undefined mimetype on some http requests.

### DIFF
--- a/lib/HTTPServer.pm
+++ b/lib/HTTPServer.pm
@@ -167,14 +167,16 @@ sub http_header {
 	print "Server: Monitorix HTTP Server\r\n";
 	print "Connection: close\r\n";
 
-	if($mimetype =~ m/(html|cgi)/) {
-		print "Content-Type: text/html; charset=UTF-8\r\n";
-	} elsif($mimetype eq "css") {
-		print "Content-Type: text/css; charset=UTF-8\r\n";
-	} elsif($mimetype eq "svg") {
-		print "Content-Type: image/svg+xml; charset=UTF-8\r\n";
-	} else {
-		print "Content-Type: image/$mimetype;\r\n";
+	if (defined($mimetype)) {
+		if($mimetype =~ m/(html|cgi)/) {
+			print "Content-Type: text/html; charset=UTF-8\r\n";
+		} elsif($mimetype eq "css") {
+			print "Content-Type: text/css; charset=UTF-8\r\n";
+		} elsif($mimetype eq "svg") {
+			print "Content-Type: image/svg+xml; charset=UTF-8\r\n";
+		} else {
+			print "Content-Type: image/$mimetype;\r\n";
+		}
 	}
 
 	print "\r\n";


### PR DESCRIPTION
I noticed on some requests that the mime-type was not set correctly. To avoid spamming the log files we could set the content type only in cases with correctly set mime-type. 

What do you think?