### PR TITLE
Add option to disable rrd locking during cgi calls

### DIFF
--- a/man/man5/monitorix.conf.5
+++ b/man/man5/monitorix.conf.5
@@ -171,7 +171,7 @@ Default value: \fIy\fP
 .P
 .BI enable_rrd_lock
 .RS
-This option will synchronise the rrd file access by creating the file \fI/tmp/monitorix.lock\fP and use it via flock.
+This option will synchronise the rrd file access by creating the file \fI/tmp/monitorix.lock\fP and use it via flock. The read lock during the cgi call can be disabled on a per call basis via setting the environment variable \fIINHIBIT_LOCKING\fP. This is useful for modules that call the cgi function internally.
 .P
 Default value: \fIn\fP
 .RE

--- a/monitorix.cgi
+++ b/monitorix.cgi
@@ -580,7 +580,7 @@ if($mode eq "localhost") {
 	my @writers;	# array of file descriptors
 	my $children = 0;
 
-	my $lockfile_handler = lockfile_handler(\%config);
+	my $lockfile_handler = lockfile_handler(\%config) unless $ENV{INHIBIT_LOCKING};
 	global_flock($lockfile_handler, LOCK_SH);
 	foreach (split(',', $config{graph_name})) {
 		my $gn = trim($_);


### PR DESCRIPTION
For modules that need to call the cgi function internally an option to disable the locking would be nice. This way the update function can call the cgi function to produce plots from reports for example.