### PR TITLE
Add respect_power_state option

### DIFF
--- a/man/man5/monitorix.conf.5
+++ b/man/man5/monitorix.conf.5
@@ -2012,6 +2012,28 @@ This option, when enabled via \fIy\fP, combined with the \fIshow_gaps\fP option 
 .P
 Default value: \fIn\fP
 .RE
+.P
+.BI respect_power_state
+.RS
+This option, when enabled via \fIy\fP, will respect the AMD GPU D3 power state. Monitorix won't wake up a GPU in D3 power state to check the sensors values but skip it. The power state sensor has to be specified via the \fpower_states\fP option for each GPU that should be respected.
+.P
+Default value: \fIn\fP
+.RE
+.P
+.BI power_states
+.RS
+This list complements the \fBrespect_power_state\fP option. You can specify the power_state sensor for each GPU that should not be woken up if in D3.
+.P
+.RS
+<power_states>
+.br
+	amd-w6800 = /dev/hwmon-w6800/device/power_state
+.br
+	amd-rx6900 = /dev/hwmon-rx6900/device/power_state
+.br
+</power_states>
+.RE
+.RE
 .SS NVIDIA GPU temperatures and usage (nvidiagpu.pm)
 This graph is able to monitor an unlimited number of Nvidia GPUs via \fInvidia-smi\fP.
 .P

--- a/monitorix.conf
+++ b/monitorix.conf
@@ -389,9 +389,15 @@ secure_log_date_format = %b %e
 		amd-wx5100 = WX 5100
 	</map>
 	<sensors>
-		amd-w6800 = /dev/device/gpu_busy_percent, /dev/device/mem_busy_percent, /dev/freq1_input, /dev/freq2_input, /dev/device/mem_info_vram_used, /dev/power1_average, /dev/power1_cap, pwm1, /dev/temp1_input, /dev/temp2_input, /dev/temp3_input
-		amd-wx5100 = /dev/device/gpu_busy_percent, /dev/device/mem_busy_percent, /dev/freq1_input, /dev/freq2_input, /dev/device/mem_info_vram_used, power1_average, /dev/power1_cap, /dev/pwm1, /dev/temp1_input, ,
+		amd-w6800 = /dev/device1/gpu_busy_percent, /dev/device1/mem_busy_percent, /dev/device1/freq1_input, /dev/device1/freq2_input, /dev/device1/mem_info_vram_used, /dev/device1/power1_average, /dev/device1/power1_cap, /dev/device1/pwm1, /dev/device1/temp1_input, /dev/device1/temp2_input, /dev/device1/temp3_input
+		amd-wx5100 = /dev/device2/gpu_busy_percent, /dev/device2/mem_busy_percent, /dev/device2/freq1_input, /dev/device2/freq2_input, /dev/device2/mem_info_vram_used, /dev/device2/power1_average, /dev/device2/power1_cap, /dev/device2/pwm1, /dev/device2/temp1_input, ,
 	</sensors>
+
+	respect_power_state = n
+	<power_states>
+		amd-w6800 = /dev/device1/power_state
+		amd-wx5100 = /dev/device2/power_state
+	</power_states>
 
 	<alerts>
 		coretemp_enabled = n


### PR DESCRIPTION
This way a GPU in D3 power state won't be woken up for each sensor reading. The reading will continue once the GPU is powered up.