### PR TITLE
Updating apcupsd module to have the same options and fixes as the nut module

### DIFF
--- a/man/man5/monitorix.conf.5
+++ b/man/man5/monitorix.conf.5
@@ -4329,6 +4329,55 @@ WARNING: Every time the number of entries in this option changes, Monitorix will
 .P
 Default value: \fIlocalhost:3551\fP
 .RE
+.P
+.BI use_nan_for_missing_data
+.RS
+This option, when enabled via \fIy\fP, shows \fInan\fP values for missing data instead of \fI0\fP. This is useful when \fI0\fP could be mistaken for valid data.
+.P
+Default value: \fIn\fP
+.RE
+.P
+.BI gap_on_all_nan
+.RS
+This option, when enabled via \fIy\fP, combined with the \fIshow_gaps\fP option shows gaps only if all data points are \fInan\fP instead of requiring only one to be \fInan\fP for a gap. This can be useful if not all sensor data are required for normal operation.
+.P
+Default value: \fIn\fP
+.RE
+.P
+.BI skipscale_for_transfer_voltage
+.RS
+This option, when enabled via \fIy\fP, ignores the transfer voltage graph when scaling the plot axis.
+.P
+Default value: \fIn\fP
+.RE
+.P
+.BI skipscale_for_shutdown_level
+.RS
+This option, when enabled via \fIy\fP, ignores the shutdown level graph when scaling the plot axis.
+.P
+Default value: \fIn\fP
+.RE
+.P
+.BI alt_scaling_for_voltage
+.RS
+This option, when enabled via \fIy\fP, sets alternate plot axis scaling for the voltage graph. This can be useful to improve the scaling in some cases.
+.P
+Default value: \fIn\fP
+.RE
+.P
+.BI alt_scaling_for_timeleft
+.RS
+This option, when enabled via \fIy\fP, sets alternate plot axis scaling for the time left graph. This can be useful to improve the scaling in some cases.
+.P
+Default value: \fIn\fP
+.RE
+.P
+.BI alt_scaling_for_battery_voltage
+.RS
+This option, when enabled via \fIy\fP, sets alternate plot axis scaling for the battery voltage graph. This can be useful to improve the scaling in some cases.
+.P
+Default value: \fIn\fP
+.RE
 .SS Network UPS Tools statistics (nut.pm)
 This graph is able to monitor an unlimited number of Network UPS Tools (upsc) installations.
 .P


### PR DESCRIPTION
Fixing:
- Alignment of the battery percentage legend items

Adding options:
- gap_on_all_nan
- use_nan_for_missing_data
- skipscale_for_transfer_voltage
- skipscale_for_shutdown_level
- alt_scaling_for_voltage
- alt_scaling_for_timeleft
- alt_scaling_for_battery_voltage