### PR TITLE
Resolved GitHub Actions Node.js 12 deprecation warnings

### DIFF
--- a/.github/actions/yum/install/action.yml
+++ b/.github/actions/yum/install/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Cache `DNF` / `YUM`
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           /var/cache/dnf

--- a/.github/workflows/syntax-check-install-test.yml
+++ b/.github/workflows/syntax-check-install-test.yml
@@ -27,7 +27,7 @@ jobs:
       image: ${{ matrix.image }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Dependencies (Arch Linux)
         uses: ./.github/actions/pacman/install
@@ -100,7 +100,7 @@ jobs:
             /var/log/monitorix*
 
       - name: Upload `Monitorix` artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ env.image_name }}
           path: /tmp/artifacts.tar.gz


### PR DESCRIPTION
* Some actions require a version bump
  * https://github.com/actions/cache/releases/tag/v3.0.0
  * https://github.com/actions/checkout/releases/tag/v3.0.0
  * https://github.com/actions/upload-artifact/releases/tag/v3.0.0

Screenshot of the warnings from [here](https://github.com/mikaku/Monitorix/actions/runs/3288065289):
![image](https://user-images.githubusercontent.com/6109326/198204368-24e9c216-f912-4cf5-b133-d9f7bc649cd9.png)

