### PR TITLE
nut.pm: Interpret input transfer reason as a string

### DIFF
--- a/lib/nut.pm
+++ b/lib/nut.pm
@@ -465,7 +465,7 @@ sub nut_cgi {
 				$status = trim($1);
 				next;
 			}
-			if(/^input\.transfer\.reason:\s+(\d+)$/) {
+			if(/^input\.transfer\.reason:\s+(.*?)$/) {
 				$transfer = trim($1);
 				next;
 			}


### PR DESCRIPTION
I have an APC UPS that I manage with NUT. What I noticed is that the _Reason for last transfer to battery_ text field was always reported as `None`. The reason for that is that the regexp that retrieves the value was looking only for a sequence numbers, whereas `upsc` for my UPS reports `input.transfer.reason` as a string:

```
$ upsc apc 2> /dev/null | grep -E "input\.transfer\.reason"
input.transfer.reason: low utility voltage
```

Other UPS models/drivers might be reporting this value as a number, but the new regexp should catch that too:

```
$ echo 'input.transfer.reason: 69' | grep -Po '^input\.transfer\.reason:\s+\K(.*?)$'
69
```

Before the change:
![nut-transfer-reason-before](https://github.com/mikaku/Monitorix/assets/8930084/da881aeb-c3a1-48e5-a730-bb5fe22c882d)

After the change:
![nut-transfer-reason-after](https://github.com/mikaku/Monitorix/assets/8930084/b1c4d601-ece2-405b-9b54-4dd5d783a6f8)

What I used to test this:

- Monitorix version: `3.15.0-1` from Debian 12 repositories
- OS: Debian 12
- Perl: `5.36.0` from Debian 12 repositories

The `nut.pm` section of my Monitorix config:

```
<nut>
list = apc
skipscale_for_shutdown_level = y
skipscale_for_transfer_voltage = y
use_nan_for_missing_data = y
ignore_error_output = y
</nut>
```