### PR TITLE
CI Fixes: Upgrade deprecated & out-of-date Images & Actions

### DIFF
--- a/.github/actions/dnf/install/action.yml
+++ b/.github/actions/dnf/install/action.yml
@@ -1,0 +1,42 @@
+---
+inputs:
+  dependencies:
+    description: List of package(s) to pre-install
+    required: false
+  groups:
+    description: List of group(s) to install
+    required: false
+  packages:
+    description: List of package(s) to install
+    required: true
+  upgrade:
+    default: true
+    description: Upgrade packages
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Upgrade packages
+      run: |
+        dnf --assumeyes upgrade
+      shell: bash --noprofile --norc -euxo pipefail {0}
+      if: inputs.upgrade
+
+    - name: Install dependency package(s)
+      run: |
+        if [ -n "${{ inputs.dependencies }}" ]; then
+          dnf --assumeyes install ${{ inputs.dependencies }}
+        fi
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Install group(s)
+      run: |
+        if [ -n '${{ inputs.groups }}' ]; then
+          dnf --assumeyes group install ${{ inputs.groups }}
+        fi
+      shell: bash --noprofile --norc -euxo pipefail {0}
+
+    - name: Install package(s)
+      run: dnf --assumeyes install ${{ inputs.packages }}
+      shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/yum/install/action.yml
+++ b/.github/actions/yum/install/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Cache `DNF` / `YUM`
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           /var/cache/dnf

--- a/.github/workflows/syntax-check-install-test.yml
+++ b/.github/workflows/syntax-check-install-test.yml
@@ -27,7 +27,7 @@ jobs:
       image: ${{ matrix.image }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Dependencies (Arch Linux)
         uses: ./.github/actions/pacman/install
@@ -100,7 +100,7 @@ jobs:
             /var/log/monitorix*
 
       - name: Upload `Monitorix` artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.image_name }}
           path: /tmp/artifacts.tar.gz

--- a/.github/workflows/syntax-check-install-test.yml
+++ b/.github/workflows/syntax-check-install-test.yml
@@ -13,15 +13,16 @@ jobs:
       matrix:
         image:
           - archlinux:latest
-          - centos:7
-          - almalinux:8
-          - rockylinux:8
-          - debian:10
+          - quay.io/centos/centos:stream9
+          - quay.io/centos/centos:stream10
+          - almalinux:9
+          - rockylinux:9
           - debian:11
-          - fedora:34
-          - fedora:35
-          - ubuntu:20.04
+          - debian:12
+          - fedora:41
+          - fedora:42
           - ubuntu:22.04
+          - ubuntu:24.04
       fail-fast: false
     container:
       image: ${{ matrix.image }}
@@ -36,15 +37,23 @@ jobs:
         if: |
           startsWith(matrix.image, 'archlinux:')
 
-      - name: Install Dependencies (AlmaLinux/CentOS/Rocky Linux)
-        uses: ./.github/actions/yum/install
+      - name: Install EPEL repository (AlmaLinux/CentOS Stream/Rocky Linux)
+        uses: ./.github/actions/dnf/install
         with:
-          dependencies: epel-release
-          groups: ${{ env.almalinux-centos-rockylinux-group-dependencies }}
-          packages: ${{ env.almalinux-centos-rockylinux-dependencies }}
+          packages: epel-release
         if: |
           startsWith(matrix.image, 'almalinux:') ||
-          startsWith(matrix.image, 'centos:') ||
+          startsWith(matrix.image, 'quay.io/centos/centos:stream') ||
+          startsWith(matrix.image, 'rockylinux:')
+
+      - name: Install Dependencies (AlmaLinux/CentOS Stream/Rocky Linux)
+        uses: ./.github/actions/dnf/install
+        with:
+          groups: ${{ env.almalinux-centos-stream-rockylinux-group-dependencies }}
+          packages: ${{ env.almalinux-centos-stream-rockylinux-dependencies }}
+        if: |
+          startsWith(matrix.image, 'almalinux:') ||
+          startsWith(matrix.image, 'quay.io/centos/centos:stream') ||
           startsWith(matrix.image, 'rockylinux:')
 
       - name: Install Dependencies (Debian/Ubuntu)
@@ -56,7 +65,7 @@ jobs:
           startsWith(matrix.image, 'ubuntu:')
 
       - name: Install Dependencies (Fedora)
-        uses: ./.github/actions/yum/install
+        uses: ./.github/actions/dnf/install
         with:
           groups: ${{ env.fedora-group-dependencies }}
           packages: ${{ env.fedora-dependencies }}
@@ -93,7 +102,7 @@ jobs:
 
       - name: Tar `Monitorix` artifacts
         run: |
-          echo "image_name=$(echo ${{ matrix.image }} | sed 's/:/-/g')" >> \
+          echo "image_name=$(echo ${{ matrix.image }} | sed 's/[:\/]/-/g')" >> \
             $GITHUB_ENV
           tar --create --gzip --verbose --file /tmp/artifacts.tar.gz \
             /var/lib/monitorix/www \
@@ -111,13 +120,14 @@ env:
     base-devel
     cpanminus
     rrdtool
-  almalinux-centos-rockylinux-group-dependencies: >-
+  almalinux-centos-stream-rockylinux-group-dependencies: >-
     "Development Tools"
-  almalinux-centos-rockylinux-dependencies: >-
+  almalinux-centos-stream-rockylinux-dependencies: >-
     expat-devel
     openssl
     openssl-devel
     perl-App-cpanminus
+    perl-LWP-Protocol-https
     rrdtool
     rrdtool-perl
   debian-ubuntu-dependencies: >-
@@ -131,11 +141,10 @@ env:
     rrdtool
     zlib1g-dev
   fedora-group-dependencies: >-
-    "C Development Tools and Libraries"
-    "Development Libraries"
-    "Development Tools"
+    development-tools
   fedora-dependencies: >-
     expat-devel
+    libxml2-devel
     openssl
     openssl-devel
     perl-App-cpanminus


### PR DESCRIPTION
### Actions Upgraded:
- actions/upload-artifact@v3 -> actions/upload-artifact@v4
  - [Has been deprecated and is no longer available](https://github.com/actions/upload-artifact?tab=readme-ov-file)
  - This was causing the pipeline to fail completely
- actions/cache@v3 -> actions/cache@v4
- actions/checkout@v3 -> actions/checkout@v4

### Images Upgraded:
- almalinux:8 -> almalinux:9
- debian:10 -> debian:12
- fedora:34 -> fedora:41
- fedora:35 -> fedora:42
- rockylinux:8 -> rockylinux:9
- ubuntu:20.04 -> ubuntu:24.04

### Images Added:
- centos:stream9
- centos:stream10

### Images Removed:
- centos:7