### PR TITLE
Fix "Use of uninitialized value in string eq"

### DIFF
--- a/lib/Monitorix.pm
+++ b/lib/Monitorix.pm
@@ -200,7 +200,7 @@ sub httpd_setup {
 			logger("$myself: '$config->{httpd_builtin}->{auth}->{htpasswd}' $!");
 		}
 	} else {
-		if(!grep {$_ eq $config->{httpd_builtin}->{host}} ("localhost", "127.0.0.1")) {
+		if(!defined $host || !grep {$_ eq $host} ("localhost", "127.0.0.1")) {
 			logger("WARNING: the HTTP built-in server has authentication disabled.");
 		}
 	}


### PR DESCRIPTION
When using the default config, 'httpd_builtin.host' is uninitialized.
The resulting warning looks alarming to users unfamiliar with Perl (me):
```
Use of uninitialized value in string eq at /nix/store/<hash>-monitorix-3.16.0/lib/monitorix/Monitorix.pm line 203, <DATA> line 16.
```

This change avoids the "uninitialized"-warning. (but still logs the "authentication disabled"-warning)