### PR TITLE
Make responsive-check warning more descriptive.

### DIFF
--- a/monitorix
+++ b/monitorix
@@ -943,8 +943,9 @@ while(1) {
 					my $ua = LWP::UserAgent->new(timeout => 30);
 					my $response = $ua->request(HTTP::Request->new('GET', $url));
 					if(!$response->is_success) {
-						if($response->status_line ne "401 Access Denied") {
-							logger("WARNING: HTTP built-in server not responding at '$url'.");
+					    my $status = $response->status_line;
+						if($status ne "401 Access Denied") {
+							logger("WARNING: HTTP built-in server not responding at '$url'. (status: $status)");
 							exit(1);
 						}
 					}


### PR DESCRIPTION
### Scenario

When the libwww Perl collection is installed incorrectly, the HTTP protocol is not supported.

This leads to a confusing warning, and repeated restarts of the built-in server:
```
WARNING: HTTP built-in server not responding at 'http://<host>:<port>/monitorix'.
```
(the error is confusing, because the site is fully responsive to regular clients)

### Fix

Now the status line is included in the output.
This was very helpful to me for finding the actual cause.
```
WARNING: HTTP built-in server not responding at 'http://<host>:<port>/monitorix'. (status: 501 Protocol scheme 'http' is not supported)
```